### PR TITLE
Allow python versions >= 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "Flask extension based on simple-crypt that allows simple, secure encryption and decryption for Python."
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Fix for https://github.com/furritos/flask-simple-crypt/issues/3